### PR TITLE
Fixed SQL Injection on user.list.php

### DIFF
--- a/acp/core/user.list.php
+++ b/acp/core/user.list.php
@@ -106,8 +106,8 @@ $status_btn_group .= '</div>';
 $whereString = "WHERE user_nick != '' ";
 
 if(!empty($_POST['findUser'])) {
-	$findUser = strip_tags($_POST['findUser']);
-	$search_user = "user_nick LIKE '%$findUser%' ";
+	$find_user = "%".strip_tags($_POST['findUser'])."%";
+	$search_user = "user_nick LIKE :find_user ";
 }
 
 
@@ -128,8 +128,13 @@ $sql = "SELECT user_id, user_nick, user_class, user_firstname, user_lastname, us
     		FROM fc_user
     		$whereString
     		ORDER BY $order_by $way";
+$sth = $dbh->prepare($sql);
+if($search_user != "") {
+	$sth->bindParam(':find_user', $find_user, PDO::PARAM_STR);
+}
+$sth->execute();
 
-foreach ($dbh->query($sql) as $row) {
+foreach ($sth->fetchAll(PDO::FETCH_ASSOC) as $row) {
 	$result[] = $row;
 }
 


### PR DESCRIPTION
**Description**
Search filter on `http://[server name]/[base path]/acp/acp.php?tn=user&sub=list` allows user to inject malicious SQL sentence.
Fixed by using bind param.

**Reproduce**
1. Go to `http://[server name]/[base path]/acp/acp.php?tn=user&sub=list`
2. Input `test') or 1=1 union select (select tbl_name from sqlite_master limit 1),2,3,4,5,6,7,8--` into Filter input field.
![2017-09-18 0 22 30](https://user-images.githubusercontent.com/7601382/30522229-c2793e6c-9c07-11e7-8dd3-f45846c5e4ab.png)
3. Hit return key
4. You can see the user which has `ID:fc_user` like below. `fc_user` is a result of `select tbl_name from sqlite_master limit 1`.
![2017-09-18 0 25 34](https://user-images.githubusercontent.com/7601382/30522270-45df1c86-9c08-11e7-9de7-a536b313569d.png)
